### PR TITLE
Add trurl to data management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A collection of modern data migration, conversion and management tools.
 *   [unison](https://github.com/bcpierce00/unison): a file synchronizer, can keep two directories in sync bi-directionally.
 *   [sq](https://github.com/neilotoole/sq): "jq-style access to structured data sources: SQL databases, or document formats like CSV or Excel. It is the lovechild of sql+jq."
 *   [xq](https://github.com/sibprogrammer/xq): A "Command-line XML and HTML beautifier and content extractor", another in the line of tools jq has inspired.
+*   [trurl](https://curl.se/trurl/): A command line tool that parses and manipulates URLs
 
 ## Specialized tools
 


### PR DESCRIPTION
trurl is a CLI tool from the cURL project, which can help shells script authors (or any CLI users) introspect and modify URLs.